### PR TITLE
More descriptive default messages

### DIFF
--- a/src/TableFlip.php
+++ b/src/TableFlip.php
@@ -1,11 +1,11 @@
 <?php
 
 class （╯°□°）╯︵┻━┻ extends Exception {
-  public function __construct($message = "Nope!", $code = 0) {
+  public function __construct($message = "(╯°□°)╯︵┻━┻", $code = 0) {
     parent::__construct($message, $code);
   }
 }
 
-function （╯°□°）╯︵┻━┻($message = "Nope!", $code = 0) {
+function （╯°□°）╯︵┻━┻($message = "(╯°□°)╯︵┻━┻", $code = 0) {
   throw new （╯°□°）╯︵┻━┻($message, $code);
 }


### PR DESCRIPTION
Default messages converted from "Nope!" to "(╯°□°)╯︵┻━┻" with standard parentheses.
