### PR TITLE
Add ability to call 'stealth' function too, with brackets hidden in art

### DIFF
--- a/src/TableFlip.php
+++ b/src/TableFlip.php
@@ -23,3 +23,9 @@ class （ノಥ益ಥ）ノ︵┻━┻ extends Exception implements ┻━┻ {
 function （╯°□°）╯︵┻━┻($message = __FUNCTION__, $code = 0, $previous = null) {
   throw new （╯°□°）╯︵┻━┻($message, $code, $previous);
 }
+
+define('°□°└', '');
+
+function ┻━┻︵└($ignore) {
+  （╯°□°）╯︵┻━┻();
+}


### PR DESCRIPTION
If you change the art around the other way, you can use the brackets as part of the art and hide them from the function call.

You need a constant to put in the brackets and fill in the rest of the face, so this is defined as well.

Usage:
`┻━┻︵└(°□°└);`

I can't think of a way to get rid of the semi-colon unfortunately.
