### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "sgolemon/table-flip",
   "description": "Essential exception class needed by every good project.",
-  "version": "1.0.4",
   "type": "library",
   "keywords": [
     "exception",


### PR DESCRIPTION
Including it confuses Packagist (see the note on [version](https://getcomposer.org/doc/04-schema.md#version)), as it tries to infer the version from the branch or tag name instead.
