### PR TITLE
PHPUnit 6, and provide a phpunit.xml.dist file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "files": [ "src/TableFlip.php" ]
   },
   "require-dev": {
-    "phpunit/phpunit": "*"
+    "phpunit/phpunit": "^6.0.8"
   },
   "scripts": {
     "test": "vendor/bin/phpunit tests/Flip.php"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuite>
+        <directory suffix="Test.php">tests</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FlipTest.php
+++ b/tests/FlipTest.php
@@ -1,8 +1,8 @@
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+use PHPUnit\Framework\TestCase;
 
-class TableFlipTest extends PHPUnit_Framework_TestCase {
+class TableFlipTest extends TestCase {
   const TYPE_NORMAL = 0;
   const TYPE_PUDGY = 1;
   const TYPE_AGRO = 2;


### PR DESCRIPTION
Hi Sara, 
（°□°） installed table-flip, ran `composer install`, and tests failed because the composer.json file did not lock the phpunit dependency to the 5.* branch. 

Because many other libraries that makes us flip tables have moved on to PHPUnit 6 with nicer namespaced test components, may we can upgrade to 6 too?

This PR:
 - Locks the PHPUnit requirement to `~6.0.8`.
 - Adds a default `phpunit.xml.dist` so the tests can pick up the configuration automatically. 
 - Removes the `vendor/autoload.php` inclusion because PHPUnit does that for us. 
 - Makes the test `use` PHPUnit 6 `TestCase`.
 - ┬─┬